### PR TITLE
Feature/find on shelf/sort unavailable last

### DIFF
--- a/src/apps/loan-list/list/list.tsx
+++ b/src/apps/loan-list/list/list.tsx
@@ -1,4 +1,4 @@
-import React, { useState, FC, useCallback, useEffect } from "react";
+import React, { FC, useCallback, useEffect } from "react";
 import { GetMaterialManifestationQuery } from "../../../core/dbc-gateway/generated/graphql";
 import { useText } from "../../../core/utils/text";
 import IconList from "../../../components/icon-list/icon-list";

--- a/src/components/find-on-shelf/FindOnShelfModal.tsx
+++ b/src/components/find-on-shelf/FindOnShelfModal.tsx
@@ -86,7 +86,8 @@ const FindOnShelfModal: FC<FindOnShelfModalProps> = ({
       );
     }
   );
-  // "00" is the ending of beanchIds for branches that are considered main.
+  // "00" is the ending of beanchIds for branches that are considered main & should
+  // be shown first independent of whether they're available.
   const finalDataMainBranchFirst = finalDataAlphabetical.sort(
     (manifestationHolding: ManifestationHoldings) => {
       return manifestationHolding[0].holding.branch.branchId.endsWith("00")

--- a/src/components/find-on-shelf/FindOnShelfModal.tsx
+++ b/src/components/find-on-shelf/FindOnShelfModal.tsx
@@ -78,14 +78,36 @@ const FindOnShelfModal: FC<FindOnShelfModalProps> = ({
   });
 
   // Sorting of the data below to show branches & manifestations in the correct order.
-  const finalDataAlphabetical = finalData.sort(
-    (a: ManifestationHoldings, b: ManifestationHoldings) => {
-      return a[0].holding.branch.title.localeCompare(
-        b[0].holding.branch.title,
-        "da-DK"
-      );
+  function orderManifestationHoldingsAlphabetically(
+    a: ManifestationHoldings,
+    b: ManifestationHoldings
+  ) {
+    return a[0].holding.branch.title.localeCompare(
+      b[0].holding.branch.title,
+      "da-DK"
+    );
+  }
+  const availableManifestationHoldings = finalData.filter(
+    (manifestationHolding: ManifestationHoldings) => {
+      return isAnyManifestationAvailableOnBranch(manifestationHolding);
     }
   );
+  const unavailableManifestationHoldings = finalData.filter(
+    (manifestationHolding: ManifestationHoldings) => {
+      return !isAnyManifestationAvailableOnBranch(manifestationHolding);
+    }
+  );
+  const finalDataAlphabetical = availableManifestationHoldings
+    .sort((a: ManifestationHoldings, b: ManifestationHoldings) => {
+      return orderManifestationHoldingsAlphabetically(a, b);
+    })
+    .concat(
+      unavailableManifestationHoldings.sort(
+        (a: ManifestationHoldings, b: ManifestationHoldings) => {
+          return orderManifestationHoldingsAlphabetically(a, b);
+        }
+      )
+    );
   // "00" is the ending of beanchIds for branches that are considered main & should
   // be shown first independent of whether they're available.
   const finalDataMainBranchFirst = finalDataAlphabetical.sort(


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-225

#### Description
This PR introduces sorting library branches in "find on shelf modal" in **groups** - branches that have at least one available manifestation are shown first and branches without any available specimens are shown last (with the exception of any main branches that are shown on the top regardless).

#### Screenshot of the result
![image](https://user-images.githubusercontent.com/28546954/192248425-0dfbe47e-f0b8-4850-8b3b-3203464be799.png)

#### Checklist
- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
n/a
