### PR TITLE
Preserve selected periodical between material page & find on shelf modal

### DIFF
--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -66,6 +66,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
       });
       return;
     }
+
     // if there is a type, getManifestationFromType will sort and filter all manifestation and choose the first one
     const manifestationFromType = getManifestationFromType(type, work);
     if (manifestationFromType) {
@@ -135,6 +136,8 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
                 workTitles={manifestation.titles.main}
                 authors={manifestation.creators}
                 key={`find-on-shelf-modal-${manifestation.pid}`}
+                selectedPeriodical={selectedPeriodical}
+                setSelectedPeriodical={setSelectedPeriodical}
               />
               <ReservationModal
                 mainManifestation={manifestation}
@@ -173,6 +176,8 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
             manifestations={[currentManifestation]}
             workTitles={work.titles.full}
             authors={work.creators}
+            selectedPeriodical={selectedPeriodical}
+            setSelectedPeriodical={setSelectedPeriodical}
           />
           <ReservationModal
             mainManifestation={currentManifestation}

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -33,7 +33,7 @@ import {
   materialIsFiction
 } from "../../core/utils/helpers/general";
 import ReservationModal from "../../components/reservation/ReservationModal";
-import { GroupListItem } from "../../components/material/periodical/helper";
+import { PeriodicalEdition } from "../../components/material/periodical/helper";
 
 export interface MaterialProps {
   wid: WorkId;
@@ -46,7 +46,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
     useState<Manifestation | null>(null);
 
   const [selectedPeriodical, setSelectedPeriodical] =
-    useState<GroupListItem | null>(null);
+    useState<PeriodicalEdition | null>(null);
 
   const { data, isLoading } = useGetMaterialQuery({
     wid

--- a/src/components/find-on-shelf/FindOnShelfModal.tsx
+++ b/src/components/find-on-shelf/FindOnShelfModal.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { FC, useState } from "react";
+import { FC } from "react";
 import partition from "lodash.partition";
 import { isAnyManifestationAvailableOnBranch } from "../../apps/material/helper";
 import { useGetHoldingsV3 } from "../../core/fbs/fbs";

--- a/src/components/find-on-shelf/FindOnShelfModal.tsx
+++ b/src/components/find-on-shelf/FindOnShelfModal.tsx
@@ -18,7 +18,7 @@ import { FaustId } from "../../core/utils/types/ids";
 import Disclosure from "../material/disclosures/disclosure";
 import FindOnShelfManifestationList from "./FindOnShelfManifestationList";
 import FindOnShelfPeriodicalDropdowns from "./FindOnShelfPeriodicalDropdowns";
-import { GroupListItem } from "../material/periodical/helper";
+import { PeriodicalEdition } from "../material/periodical/helper";
 
 export const findOnShelfModalId = (faustId: FaustId) =>
   `find-on-shelf-modal-${faustId}`;
@@ -27,8 +27,8 @@ export interface FindOnShelfModalProps {
   manifestations: Manifestation[];
   workTitles: string[];
   authors: Work["creators"];
-  selectedPeriodical: GroupListItem | null;
-  setSelectedPeriodical: (selectedPeriodical: GroupListItem) => void;
+  selectedPeriodical: PeriodicalEdition | null;
+  setSelectedPeriodical: (selectedPeriodical: PeriodicalEdition) => void;
 }
 
 const FindOnShelfModal: FC<FindOnShelfModalProps> = ({

--- a/src/components/find-on-shelf/FindOnShelfModal.tsx
+++ b/src/components/find-on-shelf/FindOnShelfModal.tsx
@@ -13,11 +13,12 @@ import {
 import Modal from "../../core/utils/modal";
 import { useText } from "../../core/utils/text";
 import { Manifestation, Work } from "../../core/utils/types/entities";
-import { ManifestationHoldings, SelectedPeriodicalEdition } from "./types";
+import { ManifestationHoldings } from "./types";
 import { FaustId } from "../../core/utils/types/ids";
 import Disclosure from "../material/disclosures/disclosure";
 import FindOnShelfManifestationList from "./FindOnShelfManifestationList";
 import FindOnShelfPeriodicalDropdowns from "./FindOnShelfPeriodicalDropdowns";
+import { GroupListItem } from "../material/periodical/helper";
 
 export const findOnShelfModalId = (faustId: FaustId) =>
   `find-on-shelf-modal-${faustId}`;
@@ -26,12 +27,16 @@ export interface FindOnShelfModalProps {
   manifestations: Manifestation[];
   workTitles: string[];
   authors: Work["creators"];
+  selectedPeriodical: GroupListItem | null;
+  setSelectedPeriodical: (selectedPeriodical: GroupListItem) => void;
 }
 
 const FindOnShelfModal: FC<FindOnShelfModalProps> = ({
   manifestations,
   workTitles,
-  authors
+  authors,
+  selectedPeriodical,
+  setSelectedPeriodical
 }) => {
   const t = useText();
   const pidArray = getManifestationsPids(manifestations);
@@ -53,8 +58,6 @@ const FindOnShelfModal: FC<FindOnShelfModalProps> = ({
       return materialType.specific.includes("periodikum");
     });
   });
-  const [selectedPeriodicalEdition, setSelectedPeriodicalEdition] =
-    useState<SelectedPeriodicalEdition | null>(null);
 
   if (isError || !data) {
     // TODO: handle error once we have established a way to do it.
@@ -92,7 +95,7 @@ const FindOnShelfModal: FC<FindOnShelfModalProps> = ({
   // 3. Branches without available speciments sorted alphabetically
 
   // Filtering only for periodicals
-  if (selectedPeriodicalEdition) {
+  if (selectedPeriodical) {
     finalData = finalData.map((branchManifestationHoldings) => {
       return branchManifestationHoldings
         .map((manifestationHoldings) => {
@@ -104,9 +107,9 @@ const FindOnShelfModal: FC<FindOnShelfModalProps> = ({
                 (material) => {
                   return (
                     material.periodical?.volumeNumber ===
-                      selectedPeriodicalEdition.selectedEdition &&
+                      selectedPeriodical.volumeNumber &&
                     material.periodical.volumeYear ===
-                      selectedPeriodicalEdition.selectedYear
+                      selectedPeriodical.volumeYear
                   );
                 }
               )
@@ -164,10 +167,11 @@ const FindOnShelfModal: FC<FindOnShelfModalProps> = ({
         <h2 className="text-header-h2 modal-find-on-shelf__headline">
           {`${title} / ${author}`}
         </h2>
-        {isPeriodical && (
+        {isPeriodical && selectedPeriodical && (
           <FindOnShelfPeriodicalDropdowns
             manifestationsHoldings={data}
-            setSelectedPeriodical={setSelectedPeriodicalEdition}
+            setSelectedPeriodical={setSelectedPeriodical}
+            selectedPeriodical={selectedPeriodical}
           />
         )}
         {isLoading && (

--- a/src/components/find-on-shelf/FindOnShelfPeriodicalDropdowns.tsx
+++ b/src/components/find-on-shelf/FindOnShelfPeriodicalDropdowns.tsx
@@ -2,21 +2,23 @@ import * as React from "react";
 import { FC, useState } from "react";
 import ExpandMoreIcon from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/ExpandMore.svg";
 import { HoldingsForBibliographicalRecordV3 } from "../../core/fbs/model";
-import { makePeriodicalEditionsFromHoldings } from "../material/periodical/helper";
+import {
+  GroupListItem,
+  makePeriodicalEditionsFromHoldings
+} from "../material/periodical/helper";
 import { groupObjectArrayByProperty } from "../../core/utils/helpers/general";
-import { SelectedPeriodicalEdition } from "./types";
 import { useText } from "../../core/utils/text";
 
 export interface FindOnShelfPeriodicalDropdownProps {
   manifestationsHoldings: HoldingsForBibliographicalRecordV3[];
-  setSelectedPeriodical: (
-    selectedPeriodicalEdition: SelectedPeriodicalEdition
-  ) => void;
+  setSelectedPeriodical: (selectedPeriodical: GroupListItem) => void;
+  selectedPeriodical: GroupListItem;
 }
 
 const FindOnShelfPeriodicalDropdown: FC<FindOnShelfPeriodicalDropdownProps> = ({
   manifestationsHoldings,
-  setSelectedPeriodical
+  setSelectedPeriodical,
+  selectedPeriodical
 }) => {
   const t = useText();
   const periodicalEditions = makePeriodicalEditionsFromHoldings(
@@ -30,7 +32,13 @@ const FindOnShelfPeriodicalDropdown: FC<FindOnShelfPeriodicalDropdownProps> = ({
     groupedPeriodicalEditions
   ).sort();
   const [selectedYear, setSelectedYear] = useState<string>(
-    String(sortedPeriodicalEditions.pop())
+    selectedPeriodical.volumeYear
+  );
+  const toBeSelectedPeriodical = groupedPeriodicalEditions[
+    Number(selectedYear)
+  ].find(
+    (periodicalEdition) =>
+      periodicalEdition.volumeNumber === selectedPeriodical.volumeNumber
   );
 
   return (
@@ -61,10 +69,14 @@ const FindOnShelfPeriodicalDropdown: FC<FindOnShelfPeriodicalDropdownProps> = ({
           <select
             className="dropdown__select"
             aria-label={t("findOnShelfModalPeriodicalEditionDropdownText")}
+            defaultValue={selectedPeriodical.volumeNumber}
             onChange={(e) =>
               setSelectedPeriodical({
-                selectedYear,
-                selectedEdition: e.target.value
+                volumeYear: selectedYear,
+                volumeNumber: e.target.value,
+                displayText: toBeSelectedPeriodical?.displayText || "",
+                itemNumber: toBeSelectedPeriodical?.itemNumber || "",
+                volume: toBeSelectedPeriodical?.volume || ""
               })
             }
           >

--- a/src/components/find-on-shelf/FindOnShelfPeriodicalDropdowns.tsx
+++ b/src/components/find-on-shelf/FindOnShelfPeriodicalDropdowns.tsx
@@ -3,7 +3,7 @@ import { FC, useState } from "react";
 import ExpandMoreIcon from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/ExpandMore.svg";
 import { HoldingsForBibliographicalRecordV3 } from "../../core/fbs/model";
 import {
-  GroupListItem,
+  PeriodicalEdition,
   makePeriodicalEditionsFromHoldings
 } from "../material/periodical/helper";
 import { groupObjectArrayByProperty } from "../../core/utils/helpers/general";
@@ -11,8 +11,8 @@ import { useText } from "../../core/utils/text";
 
 export interface FindOnShelfPeriodicalDropdownProps {
   manifestationsHoldings: HoldingsForBibliographicalRecordV3[];
-  setSelectedPeriodical: (selectedPeriodical: GroupListItem) => void;
-  selectedPeriodical: GroupListItem;
+  setSelectedPeriodical: (selectedPeriodical: PeriodicalEdition) => void;
+  selectedPeriodical: PeriodicalEdition;
 }
 
 const FindOnShelfPeriodicalDropdown: FC<FindOnShelfPeriodicalDropdownProps> = ({
@@ -72,8 +72,8 @@ const FindOnShelfPeriodicalDropdown: FC<FindOnShelfPeriodicalDropdownProps> = ({
             defaultValue={selectedPeriodical.volumeNumber}
             onChange={(e) =>
               setSelectedPeriodical({
-                volumeYear: selectedYear,
-                volumeNumber: e.target.value,
+                volumeYear: toBeSelectedPeriodical?.volumeYear || "",
+                volumeNumber: toBeSelectedPeriodical?.volumeNumber || "",
                 displayText: toBeSelectedPeriodical?.displayText || "",
                 itemNumber: toBeSelectedPeriodical?.itemNumber || "",
                 volume: toBeSelectedPeriodical?.volume || ""

--- a/src/components/find-on-shelf/FindOnShelfPeriodicalDropdowns.tsx
+++ b/src/components/find-on-shelf/FindOnShelfPeriodicalDropdowns.tsx
@@ -72,8 +72,8 @@ const FindOnShelfPeriodicalDropdown: FC<FindOnShelfPeriodicalDropdownProps> = ({
             defaultValue={selectedPeriodical.volumeNumber}
             onChange={(e) =>
               setSelectedPeriodical({
-                volumeYear: toBeSelectedPeriodical?.volumeYear || "",
-                volumeNumber: toBeSelectedPeriodical?.volumeNumber || "",
+                volumeYear: selectedYear,
+                volumeNumber: e.target.value || "",
                 displayText: toBeSelectedPeriodical?.displayText || "",
                 itemNumber: toBeSelectedPeriodical?.itemNumber || "",
                 volume: toBeSelectedPeriodical?.volume || ""

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -21,15 +21,15 @@ import MaterialHeaderText from "./MaterialHeaderText";
 import MaterialButtons from "./material-buttons/MaterialButtons";
 import MaterialPeriodical from "./periodical/MaterialPeriodical";
 import { Manifestation, Work } from "../../core/utils/types/entities";
-import { GroupListItem } from "./periodical/helper";
+import { PeriodicalEdition } from "./periodical/helper";
 
 interface MaterialHeaderProps {
   wid: WorkId;
   work: Work;
   manifestation: Manifestation;
   selectManifestationHandler: (manifestation: Manifestation) => void;
-  selectedPeriodical: GroupListItem | null;
-  selectPeriodicalHandler: (selectedPeriodical: GroupListItem) => void;
+  selectedPeriodical: PeriodicalEdition | null;
+  selectPeriodicalHandler: (selectedPeriodical: PeriodicalEdition) => void;
 }
 
 const MaterialHeader: React.FC<MaterialHeaderProps> = ({

--- a/src/components/material/periodical/MaterialPeriodical.tsx
+++ b/src/components/material/periodical/MaterialPeriodical.tsx
@@ -2,15 +2,15 @@ import React, { FC } from "react";
 import { useGetHoldingsV3 } from "../../../core/fbs/fbs";
 import { groupObjectArrayByProperty } from "../../../core/utils/helpers/general";
 import { FaustId } from "../../../core/utils/types/ids";
-import { GroupListItem } from "./helper";
+import { PeriodicalEdition } from "./helper";
 import MaterialPeriodicalSelect, {
   GroupList
 } from "./MaterialPeriodicalSelect";
 
 export interface MaterialPeriodicalProps {
   faustId: FaustId;
-  selectedPeriodical: GroupListItem | null;
-  selectPeriodicalHandler: (selectedPeriodical: GroupListItem) => void;
+  selectedPeriodical: PeriodicalEdition | null;
+  selectPeriodicalHandler: (selectedPeriodical: PeriodicalEdition) => void;
 }
 
 const MaterialPeriodical: FC<MaterialPeriodicalProps> = ({

--- a/src/components/material/periodical/MaterialPeriodicalSelect.tsx
+++ b/src/components/material/periodical/MaterialPeriodicalSelect.tsx
@@ -1,13 +1,13 @@
 import React, { useEffect, useState } from "react";
 import { useText } from "../../../core/utils/text";
-import { getFirstEditionFromYear, GroupListItem } from "./helper";
+import { getFirstEditionFromYear, PeriodicalEdition } from "./helper";
 
-export type GroupList = { [key: string]: GroupListItem[] };
+export type GroupList = { [key: string]: PeriodicalEdition[] };
 
 interface MaterialPeriodicalSelectProps {
   groupList: GroupList;
-  selectedPeriodical: GroupListItem | null;
-  selectPeriodicalHandler: (selectedPeriodical: GroupListItem) => void;
+  selectedPeriodical: PeriodicalEdition | null;
+  selectPeriodicalHandler: (selectedPeriodical: PeriodicalEdition) => void;
 }
 
 const MaterialPeriodicalSelect: React.FC<MaterialPeriodicalSelectProps> = ({

--- a/src/components/material/periodical/helper.ts
+++ b/src/components/material/periodical/helper.ts
@@ -1,6 +1,6 @@
 import { HoldingsV3 } from "../../../core/fbs/model/holdingsV3";
 
-export type GroupListItem = {
+export type PeriodicalEdition = {
   displayText: string;
   itemNumber: string;
   volume: string;
@@ -10,7 +10,7 @@ export type GroupListItem = {
 
 export const getFirstEditionFromYear = <T extends string>(
   year: T,
-  groupList: { [key in T]: GroupListItem[] }
+  groupList: { [key in T]: PeriodicalEdition[] }
 ) => {
   return groupList[year][0];
 };

--- a/src/components/reservation/ReservationModal.tsx
+++ b/src/components/reservation/ReservationModal.tsx
@@ -4,7 +4,7 @@ import Modal from "../../core/utils/modal";
 import { useText } from "../../core/utils/text";
 import { Manifestation } from "../../core/utils/types/entities";
 import { FaustId } from "../../core/utils/types/ids";
-import { GroupListItem } from "../material/periodical/helper";
+import { PeriodicalEdition } from "../material/periodical/helper";
 import ReservationModalBody from "./ReservationModalBody";
 
 export const reservationModalId = (faustId: FaustId) =>
@@ -13,7 +13,7 @@ export const reservationModalId = (faustId: FaustId) =>
 type ReservationModalProps = {
   mainManifestation: Manifestation;
   parallelManifestations?: Manifestation[];
-  selectedPeriodical?: GroupListItem | null;
+  selectedPeriodical?: PeriodicalEdition | null;
 };
 
 const ReservationModal = ({

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -36,7 +36,7 @@ import {
   getAuthorLine
 } from "./helper";
 import UseReservableManifestations from "../../core/utils/UseReservableManifestations";
-import { GroupListItem } from "../material/periodical/helper";
+import { PeriodicalEdition } from "../material/periodical/helper";
 
 export const reservationModalId = (faustId: FaustId) =>
   `reservation-modal-${faustId}`;
@@ -44,7 +44,7 @@ export const reservationModalId = (faustId: FaustId) =>
 type ReservationModalProps = {
   mainManifestation: Manifestation;
   parallelManifestations?: Manifestation[];
-  selectedPeriodical: GroupListItem | null;
+  selectedPeriodical: PeriodicalEdition | null;
 };
 
 const ReservationModalBody = ({

--- a/src/components/reservation/helper.ts
+++ b/src/components/reservation/helper.ts
@@ -14,7 +14,7 @@ import {
   materialIsFiction
 } from "../../core/utils/helpers/general";
 import { Manifestation } from "../../core/utils/types/entities";
-import { GroupListItem } from "../material/periodical/helper";
+import { PeriodicalEdition } from "../material/periodical/helper";
 
 export const smsNotificationsIsEnabled = (config: UseConfigFunction) =>
   config("smsNotificationsForReservationsEnabledConfig") === "1";
@@ -52,7 +52,7 @@ export const getFutureDateString = (num: number) => {
   return futureDate;
 };
 
-type Periodical = Pick<GroupListItem, "volumeNumber" | "volumeYear">;
+type Periodical = Pick<PeriodicalEdition, "volumeNumber" | "volumeYear">;
 
 const constructReservation = ({
   manifestation: { pid },
@@ -104,7 +104,7 @@ export const constructReservationData = ({
   manifestations: Manifestation[];
   selectedBranch: string | null;
   expiryDate: string | null;
-  periodical: GroupListItem | null;
+  periodical: PeriodicalEdition | null;
 }): CreateReservationBatchV2 => {
   return {
     reservations: constructReservations({


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-229

#### Description
This PR adds the functionality to preserve selected periodical year and edition between material page and the find on shelf modal component.

#### Screenshot of the result
https://user-images.githubusercontent.com/28546954/193814014-f6ce8bc3-a8b9-4bf8-9c23-068c4240897c.mov

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
n/a
