### PR TITLE
Prevent type from being set in Storybook urls in Cypress tests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -148,6 +148,24 @@
         // and want to show the props being used we disable this rule.
         "@typescript-eslint/no-unused-vars": "off"
       }
+    },
+    {
+      "files": [
+        "*.test.js",
+        "*.test.jsx",
+        "*.test.ts",
+        "*.test.tsx"
+      ],
+      "rules": {
+        "no-restricted-syntax": [
+          "warn",
+          {
+            "selector": "CallExpression[callee.object.name=\"cy\"][callee.property.name=\"visit\"][arguments.0.value=/&type=/]",
+            "message": "Storybook urls for Cypress tests should not include a preselected type"
+          }
+        ]
+      }
+
     }
   ]
 }

--- a/src/apps/material/instant-loan.test.ts
+++ b/src/apps/material/instant-loan.test.ts
@@ -46,7 +46,7 @@ describe("Instant Loan", () => {
 
     cy.createFakeAuthenticatedSession();
     cy.visit(
-      "/iframe.html?&id=apps-material--instant-loan&viewMode=story&type=bog"
+      "/iframe.html?&id=apps-material--instant-loan&viewMode=story"
     ).scrollTo("bottom");
     cy.getBySel("material-description").scrollIntoView();
     cy.getBySel("material-header-buttons-physical")

--- a/src/apps/material/login-redirect.test.ts
+++ b/src/apps/material/login-redirect.test.ts
@@ -4,7 +4,7 @@ describe("Material", () => {
   it("Redirects to login & opens reservation modal on subsequent land-in", () => {
     window.sessionStorage.removeItem("user");
 
-    cy.visit("/iframe.html?id=apps-material--default&type=bog&");
+    cy.visit("/iframe.html?id=apps-material--default");
 
     cy.wait("@getMaterial GraphQL operation");
 
@@ -32,7 +32,7 @@ describe("Material", () => {
       fixtureFilePath: "material/holdings.json"
     });
 
-    cy.visit("/iframe.html?id=apps-material--default&type=bog");
+    cy.visit("/iframe.html?id=apps-material--default");
     cy.wait("@getMaterial GraphQL operation");
 
     // Activate lazy loading

--- a/src/apps/material/material.test.ts
+++ b/src/apps/material/material.test.ts
@@ -6,7 +6,7 @@ describe("Material", () => {
       operationName: "getMaterial",
       fixtureFilePath: "material/fbi-api.json"
     });
-    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story");
     cy.get(".text-header-h1").should("be.visible");
   });
 
@@ -15,7 +15,7 @@ describe("Material", () => {
       operationName: "getMaterial",
       fixtureFilePath: "material/fbi-api.json"
     });
-    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story");
 
     cy.get("img").should("have.attr", "src").and("match", coverUrlPattern);
   });
@@ -25,7 +25,7 @@ describe("Material", () => {
       operationName: "getMaterial",
       fixtureFilePath: "material/fbi-api.json"
     });
-    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story");
     cy.get(".button-favourite").should(
       "have.attr",
       "aria-label",
@@ -39,7 +39,7 @@ describe("Material", () => {
       fixtureFilePath: "material/fbi-api.json"
     });
 
-    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story");
 
     cy.getBySel("material-header-content").scrollIntoView();
 
@@ -69,7 +69,7 @@ describe("Material", () => {
       operationName: "getMaterial",
       fixtureFilePath: "material/fbi-api.json"
     });
-    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story");
 
     cy.getBySel("material-header-author-text")
       .should("be.visible")
@@ -82,7 +82,7 @@ describe("Material", () => {
       fixtureFilePath: "material/fbi-api.json"
     });
 
-    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story");
 
     cy.getBySel("material-header-content").scrollIntoView();
 
@@ -98,7 +98,7 @@ describe("Material", () => {
       fixtureFilePath: "material/fbi-api.json"
     });
 
-    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story");
 
     cy.getBySel("material-description").scrollIntoView();
 
@@ -116,7 +116,7 @@ describe("Material", () => {
       fixtureFilePath: "material/fbi-api.json"
     });
 
-    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story");
 
     cy.getBySel("material-details-disclosure").click();
   });
@@ -127,7 +127,7 @@ describe("Material", () => {
       fixtureFilePath: "material/fbi-api.json"
     });
 
-    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story");
 
     cy.scrollTo("bottom");
 
@@ -146,7 +146,7 @@ describe("Material", () => {
     });
 
     cy.createFakeAuthenticatedSession();
-    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story");
 
     cy.getBySel("material-description").scrollIntoView();
 
@@ -177,9 +177,9 @@ describe("Material", () => {
       fixtureFilePath: "material/fbi-api.json"
     });
     cy.createFakeAuthenticatedSession();
-    cy.visit(
-      "/iframe.html?id=apps-material--default&viewMode=story&type=bog"
-    ).scrollTo("bottom");
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story").scrollTo(
+      "bottom"
+    );
 
     cy.getBySel("material-description").scrollIntoView();
 
@@ -221,7 +221,7 @@ describe("Material", () => {
       operationName: "getReviewManifestations",
       fixtureFilePath: "material/reviews.json"
     });
-    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story");
 
     cy.scrollTo("bottom");
     cy.getBySel("material-reviews-disclosure").should("be.visible").click();
@@ -237,7 +237,7 @@ describe("Material", () => {
       fixtureFilePath: "material/fbi-api.json"
     });
 
-    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story");
 
     cy.getBySel("material-description").scrollIntoView();
 
@@ -254,7 +254,7 @@ describe("Material", () => {
       fixtureFilePath: "material/fbi-api.json"
     });
 
-    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story");
 
     cy.getBySel("material-description").scrollIntoView();
 

--- a/src/apps/material/order-digital-copy.test.ts
+++ b/src/apps/material/order-digital-copy.test.ts
@@ -44,9 +44,7 @@ describe("Material - Order digital copy", () => {
       statusCode: 404
     }).as("Favorite list service");
 
-    cy.visit(
-      "/iframe.html?id=apps-material--digital&viewMode=story&type=tidsskriftsartikel"
-    );
+    cy.visit("/iframe.html?id=apps-material--digital&viewMode=story");
     cy.createFakeAuthenticatedSession();
     cy.scrollTo("bottom");
   });

--- a/src/apps/material/periodical.test.ts
+++ b/src/apps/material/periodical.test.ts
@@ -44,9 +44,7 @@ describe("Material - Periodical", () => {
     });
 
     cy.createFakeAuthenticatedSession();
-    cy.visit(
-      "/iframe.html?id=apps-material--periodical&viewMode=story&type=tidsskrift"
-    );
+    cy.visit("/iframe.html?id=apps-material--periodical&viewMode=story");
   });
 
   it("Render periodical + change to 2021, nr. 52 + Aprove resevation", () => {

--- a/src/components/material/material-buttons/material-buttons.test.ts
+++ b/src/components/material/material-buttons/material-buttons.test.ts
@@ -7,7 +7,7 @@ describe("Material buttons", () => {
       url: "**/availability/v3?recordid=**",
       fixtureFilePath: "material/unavailability.json"
     });
-    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog")
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story")
       .getBySel("material-description")
       .scrollIntoView();
 
@@ -18,7 +18,7 @@ describe("Material buttons", () => {
   });
 
   it("Doesn't render find on shelf button for online materials", () => {
-    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog")
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story")
       .getBySel("material-description")
       .scrollIntoView();
 
@@ -30,7 +30,7 @@ describe("Material buttons", () => {
   });
 
   it("Renders a reservation button for physical materials with material type", () => {
-    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog")
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story")
       .getBySel("material-description")
       .scrollIntoView();
 
@@ -53,7 +53,7 @@ describe("Material buttons", () => {
       url: "**/availability/v3?recordid=**",
       fixtureFilePath: "material/unavailability.json"
     });
-    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog")
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story")
       .getBySel("material-description")
       .scrollIntoView();
 
@@ -64,7 +64,7 @@ describe("Material buttons", () => {
   });
 
   it("Renders the correct action button for ebooks from ereolen", () => {
-    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog")
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story")
       .getBySel("material-description")
       .scrollIntoView();
 
@@ -73,7 +73,7 @@ describe("Material buttons", () => {
   });
 
   it("Renders the correct action button for movies from filmstriben", () => {
-    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog")
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story")
       .getBySel("material-description")
       .scrollIntoView();
 
@@ -84,7 +84,7 @@ describe("Material buttons", () => {
   });
 
   it("Renders the correct action button for online audio books", () => {
-    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog")
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story")
       .getBySel("material-description")
       .scrollIntoView();
 
@@ -93,7 +93,7 @@ describe("Material buttons", () => {
   });
 
   it("Renders the correct action button for other online materials", () => {
-    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog")
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story")
       .getBySel("material-description")
       .scrollIntoView();
 
@@ -107,9 +107,7 @@ describe("Material buttons", () => {
       fixtureFilePath:
         "material-buttons/material-buttons-order-digital-fbi-api.json"
     });
-    cy.visit(
-      "/iframe.html?id=apps-material--digital&viewMode=story&type=tidsskriftsartikel"
-    )
+    cy.visit("/iframe.html?id=apps-material--digital&viewMode=story")
       .getBySel("material-description")
       .scrollIntoView();
 
@@ -140,7 +138,7 @@ describe("Material buttons", () => {
       fixtureFilePath: "material/user-blocked.json"
     });
     cy.createFakeAuthenticatedSession();
-    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog")
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story")
       .getBySel("material-description")
       .scrollIntoView();
 

--- a/src/components/reservation/reservation.test.ts
+++ b/src/components/reservation/reservation.test.ts
@@ -57,7 +57,7 @@ describe("Reservation", () => {
 
     // We simulate that the user is logged in so that we can open the modal.
     cy.createFakeAuthenticatedSession();
-    cy.visit("/iframe.html?id=apps-material--default&type=bog");
+    cy.visit("/iframe.html?id=apps-material--default");
 
     cy.scrollTo("bottom");
     // eslint-disable-next-line
@@ -87,7 +87,7 @@ describe("Reservation", () => {
 
     // We simulate that the user is logged in so that we can open the modal.
     cy.createFakeAuthenticatedSession();
-    cy.visit("/iframe.html?id=apps-material--turen-gar-til-rom&type=bog");
+    cy.visit("/iframe.html?id=apps-material--turen-gar-til-rom");
 
     cy.scrollTo("bottom");
     // eslint-disable-next-line


### PR DESCRIPTION
The normal flow of rendering materials is that if no material type is set then one will be detected automatically and the url with be updated accordingly.

If the type in the url does not match a for the current the current  material e.g. then rendering of the material app can stop at the  skeleton screen. This can be caused by updated material types for the material or updated material names.

To avoid this we configure Eslint to warn if such urls are called through AST analysis and regular expressions.
