### PR TITLE
Fishery fixtures proof-of-concept

### DIFF
--- a/cypress/factories/availability.ts
+++ b/cypress/factories/availability.ts
@@ -1,0 +1,11 @@
+import { Factory } from "fishery";
+import { AvailabilityV3 } from "../../src/core/fbs/model/availabilityV3";
+
+export default Factory.define<AvailabilityV3>(() => ({
+  // We have to provide default values for all required fields. Fishery does
+  // not provide a way to force the caller to provide values.
+  recordId: "123456",
+  available: true,
+  reservable: true,
+  reservations: 0
+}));

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "eslint-plugin-react": "^7.29.4",
     "eslint-plugin-react-hooks": "^4.5.0",
     "eslint-webpack-plugin": "^3.1.1",
+    "fishery": "^2.2.2",
     "glob": "^8.0.1",
     "happy-dom": "^7.6.7",
     "istanbul-lib-coverage": "^3.2.0",

--- a/src/apps/material/material.test.ts
+++ b/src/apps/material/material.test.ts
@@ -1,3 +1,5 @@
+import AvailabilityFactory from "../../../cypress/factories/availability";
+
 const coverUrlPattern = /^https:\/\/res\.cloudinary\.com\/.*\.(jpg|jpeg|png)$/;
 
 describe("Material", () => {
@@ -297,11 +299,11 @@ describe("Material", () => {
       fixtureFilePath: "cover.json"
     });
 
-    cy.interceptRest({
-      aliasName: "Availability",
-      url: "**/availability/v3?recordid=**",
-      fixtureFilePath: "material/availability.json"
-    });
+    cy.intercept(
+      "GET",
+      "**/availability/v3?recordid=**",
+      AvailabilityFactory.buildList(1, { recordId: "46615743" })
+    ).as("Availability");
 
     // Intercept like button
     cy.intercept("HEAD", "**/list/default/**", {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10332,6 +10332,13 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+fishery@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/fishery/-/fishery-2.2.2.tgz#94d3d9380295dd3ce555021e9353c5348b8beb77"
+  integrity sha512-jeU0nDhPHJkupmjX+r9niKgVMTBDB8X+U/pktoGHAiWOSyNlMd0HhmqnjrpjUOCDPJYaSSu4Ze16h6dZOKSp2w==
+  dependencies:
+    lodash.mergewith "^4.6.2"
+
 flat-cache@^3.0.4:
   version "3.0.4"
   resolved "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz"
@@ -13429,6 +13436,11 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.mergewith@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
+  integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
 
 lodash.omit@^4.5.0:
   version "4.5.0"


### PR DESCRIPTION
Add Fishery as an alternative static JSON files for Cypress fixtures

Fishery seems to a reasonably popular fixture factory library with
support for TypeScript. See their initial blog post for more info:
https://thoughtbot.com/blog/announcing-fishery-a-javascript-and-typescript-factory-library

Alternatives considered:
- https://github.com/willryan/factory.ts (less popular, no company backing)
- https://github.com/rosiejs/rosie (no TypeScript support)


Add an initial factory for Availability

This is a reasonably simple type. It should be a nice place to start.


Use AvailabilityFactory instead of fixture in material test

This should show that the approach works in practice.

We cannot use interceptRest here as it requires a filename argument.
