### PR TITLE
Separate advanced search object and search query handling

### DIFF
--- a/src/apps/advanced-search/AdvancedSearch.tsx
+++ b/src/apps/advanced-search/AdvancedSearch.tsx
@@ -1,6 +1,8 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import AdvancedSearchHeader from "../../components/advanced-search/AdvancedSearchHeader";
 import AdvancedSearchResult from "../../components/advanced-search/AdvancedSearchResults";
+import { AdvancedSearchQuery } from "../../core/utils/types/advanced-search-types";
+import { translateSearchObjectToCql } from "./helpers";
 
 interface AdvancedSearchProps {
   pageSize: number;
@@ -8,10 +10,26 @@ interface AdvancedSearchProps {
 
 const AdvancedSearch: React.FC<AdvancedSearchProps> = ({ pageSize }) => {
   const [searchQuery, setSearchQuery] = useState<string | null>(null);
+  const [searchObject, setSearchObject] = useState<AdvancedSearchQuery | null>(
+    null
+  );
+
+  useEffect(() => {
+    if (searchObject === null) return;
+    const cql = translateSearchObjectToCql(searchObject);
+    if (cql.trim() === "") return;
+
+    setSearchQuery(cql);
+  }, [searchObject]);
 
   return (
     <div className="advanced-search">
-      <AdvancedSearchHeader setSearchQuery={setSearchQuery} />
+      <AdvancedSearchHeader
+        searchObject={searchObject}
+        setSearchObject={setSearchObject}
+        searchQuery={searchQuery}
+        setSearchQuery={setSearchQuery}
+      />
       {searchQuery && (
         <AdvancedSearchResult q={searchQuery} pageSize={pageSize} />
       )}

--- a/src/apps/advanced-search/helper.ts
+++ b/src/apps/advanced-search/helper.ts
@@ -1,5 +1,0 @@
-export const copyTextToClipboard = (text: string) => {
-  navigator.clipboard.writeText(text);
-};
-
-export default {};

--- a/src/apps/advanced-search/helpers.tsx
+++ b/src/apps/advanced-search/helpers.tsx
@@ -1,6 +1,8 @@
 import {
   AdvancedSearchRowData,
-  advancedSearchFilters
+  advancedSearchFilters,
+  AdvancedSearchQuery,
+  AdvancedSearchFilterData
 } from "../../core/utils/types/advanced-search-types";
 import { MultiselectOption } from "../../core/utils/types/multiselect-types";
 
@@ -20,9 +22,7 @@ const getSpace = (currentText: string) => {
   return space;
 };
 
-export const translateRowsToCql = (
-  rowsToTranslate: AdvancedSearchRowData[]
-) => {
+const translateRowsToCql = (rowsToTranslate: AdvancedSearchRowData[]) => {
   return rowsToTranslate.reduce((acc: string, curr: AdvancedSearchRowData) => {
     let rowTranslation = "";
     if (acc !== "" && curr.term.trim() !== "") {
@@ -43,7 +43,7 @@ export const translateRowsToCql = (
   }, "");
 };
 
-export const translateFilterToCql = (
+const translateFilterToCql = (
   filterToTranslate: MultiselectOption[],
   cqlKey: keyof typeof advancedSearchFilters
 ) => {
@@ -60,6 +60,38 @@ export const translateFilterToCql = (
     );
     return acc + filterTranslation;
   }, "");
+};
+
+const translateFiltersToCql = (
+  filtersToTranslate: AdvancedSearchFilterData
+) => {
+  const filtersAsArray: MultiselectOption[][] = Object.keys(
+    filtersToTranslate
+  ).map((key) => filtersToTranslate[key as keyof AdvancedSearchFilterData]);
+
+  const translatedFilters = filtersAsArray.reduce(
+    (acc: string, curr: MultiselectOption[], index) => {
+      return (
+        acc +
+        translateFilterToCql(
+          curr,
+          Object.keys(filtersToTranslate)[
+            index
+          ] as keyof typeof advancedSearchFilters
+        )
+      );
+    },
+    ""
+  );
+  return translatedFilters;
+};
+
+export const translateSearchObjectToCql = (
+  searchObject: AdvancedSearchQuery
+) => {
+  const rowsAsCql = translateRowsToCql(searchObject.rows);
+  const filtersAsCql = translateFiltersToCql(searchObject.filters);
+  return rowsAsCql + filtersAsCql;
 };
 
 export default {};

--- a/src/components/advanced-search/AdvancedSearchRow.tsx
+++ b/src/components/advanced-search/AdvancedSearchRow.tsx
@@ -9,35 +9,36 @@ import {
   AdvancedSearchIndex,
   AdvancedSearchIndexTranslations,
   AdvancedSearchIndexes,
+  AdvancedSearchQuery,
+  initialAdvancedSearchQuery,
   AdvancedSearchRowData
 } from "../../core/utils/types/advanced-search-types";
 import { useText } from "../../core/utils/text";
 
 export type AdvancedSearchRowProps = {
+  data: AdvancedSearchQuery;
   dataCy?: string;
-  data: AdvancedSearchRowData[];
   rowIndex: number;
-  setRowsData: (data: AdvancedSearchRowData[]) => void;
+  setSearchObject: (searchObject: AdvancedSearchQuery) => void;
 };
 
 const AdvancedSearchRow: React.FC<AdvancedSearchRowProps> = ({
   dataCy = "advanced-search-row",
   data,
   rowIndex,
-  setRowsData
+  setSearchObject
 }) => {
   const t = useText();
 
   const updateRowData = (
     rowAspect: "term" | "clause" | "searchIndex",
     update: string | AdvancedSearchClause | AdvancedSearchIndex,
-    rowData: AdvancedSearchRowData[],
-    updateData: (data: AdvancedSearchRowData[]) => void
+    updateData: (data: AdvancedSearchQuery) => void
   ) => {
-    const newData = [...rowData];
+    const newData = { ...data };
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore-next-line
-    newData[rowIndex][rowAspect] = update;
+    newData.rows[rowIndex][rowAspect] = update;
     updateData(newData);
   };
 
@@ -50,19 +51,20 @@ const AdvancedSearchRow: React.FC<AdvancedSearchRowProps> = ({
     });
   };
 
-  const addRow = (updateData: (data: AdvancedSearchRowData[]) => void) => {
-    const newData = [...data];
-    newData.push({ term: "", searchIndex: "all", clause: "AND" });
+  const addRow = (updateData: (data: AdvancedSearchQuery) => void) => {
+    const newData = { ...data };
+    newData.rows.push(
+      initialAdvancedSearchQuery.rows.at(0) as AdvancedSearchRowData
+    );
     updateData(newData);
   };
 
   const removeRow = (
     index: number,
-    rowData: AdvancedSearchRowData[],
-    updateData: (data: AdvancedSearchRowData[]) => void
+    updateData: (data: AdvancedSearchQuery) => void
   ) => {
-    const newData = [...rowData];
-    newData.splice(index, 1);
+    const newData = { ...data };
+    newData.rows.splice(index, 1);
     updateData(newData);
   };
 
@@ -75,9 +77,9 @@ const AdvancedSearchRow: React.FC<AdvancedSearchRowProps> = ({
               <button
                 key={clause}
                 type="button"
-                className={getClauseClasses(clause, data[rowIndex].clause)}
+                className={getClauseClasses(clause, data.rows[rowIndex].clause)}
                 onClick={() => {
-                  updateRowData("clause", clause, data, setRowsData);
+                  updateRowData("clause", clause, setSearchObject);
                 }}
               >
                 {clause}
@@ -92,18 +94,18 @@ const AdvancedSearchRow: React.FC<AdvancedSearchRowProps> = ({
           className="input-with-dropdown__input focus-styling__input capitalize-first"
           type="text"
           placeholder={t("advancedSearchInputPlaceholderText")}
-          value={data[rowIndex].term}
+          value={data.rows[rowIndex].term}
           onChange={(e) => {
-            updateRowData("term", e.target.value, data, setRowsData);
+            updateRowData("term", e.target.value, setSearchObject);
           }}
         />
         <div className="dropdown dropdown--grey-borders input-with-dropdown__dropdown">
           <select
             className="dropdown__select dropdown__select--inline focus-styling"
             aria-label="input field dropdown"
-            value={data[rowIndex].searchIndex}
+            value={data.rows[rowIndex].searchIndex}
             onChange={(e) => {
-              updateRowData("searchIndex", e.target.value, data, setRowsData);
+              updateRowData("searchIndex", e.target.value, setSearchObject);
             }}
           >
             {AdvancedSearchIndexes.map((index) => {
@@ -118,11 +120,11 @@ const AdvancedSearchRow: React.FC<AdvancedSearchRowProps> = ({
             <img className="dropdown__arrow" src={IconExpand} alt="" />
           </div>
         </div>
-        {data.length > 1 && (
+        {data.rows.length > 1 && (
           <button
             type="button"
             onClick={() => {
-              removeRow(rowIndex, data, setRowsData);
+              removeRow(rowIndex, setSearchObject);
             }}
           >
             <img className="input-with-dropdown__icon" src={IconMinus} alt="" />
@@ -130,12 +132,12 @@ const AdvancedSearchRow: React.FC<AdvancedSearchRowProps> = ({
         )}
       </div>
 
-      {rowIndex === data.length - 1 && (
+      {rowIndex === data.rows.length - 1 && (
         <button
           type="button"
           className="advanced-search__clauses cursor-pointer"
           onClick={() => {
-            addRow(setRowsData);
+            addRow(setSearchObject);
           }}
         >
           <img className="mr-8" src={IconPlus} alt="" />

--- a/src/components/advanced-search/PreviewSection.tsx
+++ b/src/components/advanced-search/PreviewSection.tsx
@@ -2,21 +2,18 @@ import React, { useEffect, useState } from "react";
 import clsx from "clsx";
 import { useCopyToClipboard } from "react-use";
 import CheckIcon from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/Check.svg";
-import { AdvancedSearchRowData } from "../../core/utils/types/advanced-search-types";
 import { useText } from "../../core/utils/text";
 
 export type PreviewSectionProps = {
   translatedCql: string;
-  setRowsData: (rowData: AdvancedSearchRowData[]) => void;
-  initialRowData: AdvancedSearchRowData[];
+  reset: () => void;
   isMobile?: boolean;
   setIsAdvancedSearchHeader: (newState: boolean) => void;
 };
 
 const PreviewSection: React.FC<PreviewSectionProps> = ({
   translatedCql,
-  setRowsData,
-  initialRowData,
+  reset,
   isMobile,
   setIsAdvancedSearchHeader
 }) => {
@@ -52,9 +49,7 @@ const PreviewSection: React.FC<PreviewSectionProps> = ({
         <button
           type="button"
           className="link-tag mr-16 cursor-pointer capitalize-first"
-          onClick={() => {
-            setRowsData(initialRowData);
-          }}
+          onClick={() => reset()}
         >
           {t("advancedSearchResetText")}
         </button>

--- a/src/core/utils/types/advanced-search-types.ts
+++ b/src/core/utils/types/advanced-search-types.ts
@@ -76,6 +76,23 @@ export type AdvancedSearchFilterData = {
   accessibility: MultiselectOption[];
 };
 
+export type AdvancedSearchQuery = {
+  rows: AdvancedSearchRowData[];
+  filters: AdvancedSearchFilterData;
+};
+
+export const initialAdvancedSearchQuery: AdvancedSearchQuery = {
+  rows: [
+    { term: "", searchIndex: "all", clause: "AND" },
+    { term: "", searchIndex: "all", clause: "AND" }
+  ],
+  filters: {
+    materialTypes: [{ item: "All", value: "all" }],
+    fiction: [{ item: "All", value: "all" }],
+    accessibility: [{ item: "All", value: "all" }]
+  }
+};
+
 export const advancedSearchMaterialTypes: MultiselectOption[] = [
   { item: "Bog", value: "bøger" },
   { item: "E-bog", value: "e-bøger" },


### PR DESCRIPTION
We want to separate between two modes of searching:

1. Combining queries, indexes, operators and filters through our  advanced search form (search object)
2. Entering a direct CQL query (search query)

To sepatate between these two states we introduce two states for the advanced search form to correspond with each of them.

To handle this current structures for rows and filters are combined into a search query type and all code is updated accordingly.

Since translation from search query to CQL now needs to occur at two levels - preview and final search rendering - we move the helpers for managing this to a shared utility type which corresponds with our types.