### PR TITLE
Initial storage/retrieval of advanced search parameters from URL

### DIFF
--- a/src/apps/advanced-search/AdvancedSearchHeader.tsx
+++ b/src/apps/advanced-search/AdvancedSearchHeader.tsx
@@ -45,8 +45,15 @@ const AdvancedSearchHeader: React.FC<AdvancedSearchHeaderProps> = ({
   // the search button.
   const [internalSearchObject, setInternalSearchObject] =
     useState<AdvancedSearchQuery>(searchObject || initialAdvancedSearchQuery);
-  const [previewCql, setPreviewCql] = useState<string>("");
+  const [previewCql, setPreviewCql] = useState<string>(searchQuery || "");
   const [rawCql, setRawCql] = useState<string>("");
+
+  // If a new search object is passed in, override the internal state to reflect
+  // the updated values in the state.
+  useEffect(() => {
+    if (searchObject === null) return;
+    setInternalSearchObject(searchObject);
+  }, [searchObject]);
 
   useEffect(() => {
     const cql = translateSearchObjectToCql(internalSearchObject);
@@ -111,7 +118,7 @@ const AdvancedSearchHeader: React.FC<AdvancedSearchHeaderProps> = ({
               })}
             </div>
             <PreviewSection
-              translatedCql={previewCql}
+              translatedCql={previewCql || searchQuery || ""}
               reset={() => setInternalSearchObject(initialAdvancedSearchQuery)}
               setIsAdvancedSearchHeader={setIsAdvancedSearchHeader}
             />
@@ -153,7 +160,7 @@ const AdvancedSearchHeader: React.FC<AdvancedSearchHeaderProps> = ({
             </div>
           </section>
           <PreviewSection
-            translatedCql={previewCql || ""}
+            translatedCql={previewCql || searchQuery || ""}
             reset={() => setInternalSearchObject(initialAdvancedSearchQuery)}
             isMobile
             setIsAdvancedSearchHeader={setIsAdvancedSearchHeader}
@@ -161,7 +168,10 @@ const AdvancedSearchHeader: React.FC<AdvancedSearchHeaderProps> = ({
         </>
       )}
       {!isAdvancedSearchheader && (
-        <CqlSearchHeader initialCql={searchQuery || ""} setCql={setRawCql} />
+        <CqlSearchHeader
+          initialCql={previewCql || searchQuery || ""}
+          setCql={setRawCql}
+        />
       )}
 
       <section className="advanced-search__footer">

--- a/src/apps/advanced-search/AdvancedSearchHeader.tsx
+++ b/src/apps/advanced-search/AdvancedSearchHeader.tsx
@@ -129,6 +129,7 @@ const AdvancedSearchHeader: React.FC<AdvancedSearchHeaderProps> = ({
               <Multiselect
                 caption="Material types"
                 options={advancedSearchMaterialTypes}
+                defaultValue={internalSearchObject.filters.materialTypes}
                 updateExternalState={{
                   key: "materialTypes",
                   externalUpdateFunction:
@@ -140,6 +141,7 @@ const AdvancedSearchHeader: React.FC<AdvancedSearchHeaderProps> = ({
               <Multiselect
                 caption="Literature form"
                 options={advancedSearchFiction}
+                defaultValue={internalSearchObject.filters.fiction}
                 updateExternalState={{
                   key: "fiction",
                   externalUpdateFunction:
@@ -151,6 +153,7 @@ const AdvancedSearchHeader: React.FC<AdvancedSearchHeaderProps> = ({
               <Multiselect
                 caption="Access type"
                 options={advancedSearchAccessibility}
+                defaultValue={internalSearchObject.filters.accessibility}
                 updateExternalState={{
                   key: "accessibility",
                   externalUpdateFunction:

--- a/src/apps/advanced-search/AdvancedSearchHeader.tsx
+++ b/src/apps/advanced-search/AdvancedSearchHeader.tsx
@@ -75,6 +75,12 @@ const AdvancedSearchHeader: React.FC<AdvancedSearchHeaderProps> = ({
     setInternalSearchObject(newSearchObject);
   };
 
+  useEffect(() => {
+    if (searchQuery && !searchObject) {
+      setIsAdvancedSearchHeader(false);
+    }
+  }, [searchObject, searchQuery]);
+
   const handleSearchButtonClick = () => {
     if (rawCql.trim() !== "" && !isAdvancedSearchheader) {
       setSearchQuery(rawCql);

--- a/src/components/multiselect/Multiselect.dev.tsx
+++ b/src/components/multiselect/Multiselect.dev.tsx
@@ -2,6 +2,20 @@ import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import Multiselect from "./Multiselect";
 
+const options = [
+  {
+    item: "First item",
+    value: "1"
+  },
+  {
+    item: "2. item",
+    value: "2"
+  },
+  {
+    item: "III",
+    value: "3"
+  }
+];
 export default {
   title: "Components / Multiselect",
   component: Multiselect,
@@ -16,23 +30,22 @@ export default {
   },
   args: {
     caption: "Title",
-    options: [
-      {
-        item: "First item",
-        value: "1"
-      },
-      {
-        item: "2. item",
-        value: "2"
-      },
-      {
-        item: "III",
-        value: "3"
-      }
-    ]
+    options
   }
 } as ComponentMeta<typeof Multiselect>;
 
-export const Default: ComponentStory<typeof Multiselect> = (args) => (
+const Template: ComponentStory<typeof Multiselect> = (args) => (
   <Multiselect {...args} />
 );
+
+export const Default = Template.bind({});
+
+export const SingleSelected = Template.bind({});
+SingleSelected.args = {
+  defaultValue: options.slice(0, 1)
+};
+
+export const MultipleSelected = Template.bind({});
+MultipleSelected.args = {
+  defaultValue: options.slice(0, 2)
+};

--- a/src/components/multiselect/Multiselect.dev.tsx
+++ b/src/components/multiselect/Multiselect.dev.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import Multiselect from "./Multiselect";
+
+export default {
+  title: "Components / Multiselect",
+  component: Multiselect,
+  argTypes: {
+    caption: {
+      name: "Caption",
+      control: { type: "text" }
+    },
+    updateExternalState: {
+      table: { disable: true }
+    }
+  },
+  args: {
+    caption: "Title",
+    options: [
+      {
+        item: "First item",
+        value: "1"
+      },
+      {
+        item: "2. item",
+        value: "2"
+      },
+      {
+        item: "III",
+        value: "3"
+      }
+    ]
+  }
+} as ComponentMeta<typeof Multiselect>;
+
+export const Default: ComponentStory<typeof Multiselect> = (args) => (
+  <Multiselect {...args} />
+);

--- a/src/components/multiselect/Multiselect.test.ts
+++ b/src/components/multiselect/Multiselect.test.ts
@@ -1,0 +1,72 @@
+describe("Multiselect", () => {
+  beforeEach(() => {
+    cy.visit(
+      "/iframe.html?args=&id=components-multiselect--default&viewMode=story"
+    );
+  });
+
+  it("Has a title", () => {
+    cy.contains("Title");
+  });
+
+  it("Shows options and checkboxes when opened", () => {
+    cy.get("button:visible").should("contain", "All").click();
+    cy.get("[role=option]")
+      .should("contain", "All")
+      .should("contain", "First item")
+      .should("contain", "2. item")
+      .should("contain", "III");
+    cy.get("[type=checkbox]").should("have.length", 4);
+  });
+
+  it("Has the all option selected by default", () => {
+    cy.get("button:visible").should("contain", "All").click();
+    cy.get("[role=option]")
+      .contains("All")
+      .find("[type=checkbox]")
+      .should("be.checked");
+  });
+
+  it("Allows selection of single value", () => {
+    cy.get("button:visible").click();
+    cy.get("[role=option]")
+      .contains("First item")
+      .click()
+      .find("input[type=checkbox]")
+      .should("be.checked");
+    cy.get("[role=option]")
+      .contains("All")
+      .find("[type=checkbox]")
+      .should("not.be.checked");
+  });
+
+  it("Allows selection of multiple values", () => {
+    cy.get("button:visible").click();
+    cy.get("[role=option]")
+      .contains("First item")
+      .click()
+      .find("[type=checkbox]")
+      .should("be.checked");
+    cy.get("[role=option]")
+      .contains("2. item")
+      .click()
+      .find("[type=checkbox]")
+      .should("be.checked");
+    cy.get("[role=option]")
+      .contains("All")
+      .find("[type=checkbox]")
+      .should("not.be.checked");
+  });
+
+  it("Selects the all option if all values are selected", () => {
+    cy.get("button:visible").click();
+    cy.get("[role=option]").click({ multiple: true });
+    cy.get("[role=option]")
+      .contains("All")
+      .find("[type=checkbox]")
+      .should("be.checked");
+  });
+
+});
+
+export {};

--- a/src/components/multiselect/Multiselect.test.ts
+++ b/src/components/multiselect/Multiselect.test.ts
@@ -67,6 +67,30 @@ describe("Multiselect", () => {
       .should("be.checked");
   });
 
+  it("Supports single default value preselected", () => {
+    cy.visit("/iframe.html?args=&id=components-multiselect--single-selected");
+    cy.contains("First item");
+    cy.get("button:visible").click();
+    cy.get("[role=option]")
+      .contains("First item")
+      .find("[type=checkbox]")
+      .should("be.checked");
+  });
+
+  it("Supports multiple default values preselected", () => {
+    cy.visit("/iframe.html?args=&id=components-multiselect--multiple-selected");
+    cy.contains("First item");
+    cy.contains("2. item");
+    cy.get("button:visible").click();
+    cy.get("[role=option]")
+      .contains("First item")
+      .find("[type=checkbox]")
+      .should("be.checked");
+    cy.get("[role=option]")
+      .contains("2. item")
+      .find("[type=checkbox]")
+      .should("be.checked");
+  });
 });
 
 export {};

--- a/src/components/multiselect/Multiselect.tsx
+++ b/src/components/multiselect/Multiselect.tsx
@@ -1,8 +1,8 @@
-import React, { useRef, useState } from "react";
+import React, { FC, useRef, useState } from "react";
 import IconExpand from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/ExpandMore.svg";
 import { useMultipleSelection, useSelect } from "downshift";
 import clsx from "clsx";
-import { useClickAway } from "react-use";
+import { useClickAway, useDeepCompareEffect } from "react-use";
 import CheckBox from "../checkbox/Checkbox";
 import {
   MultiselectExternalUpdate,
@@ -14,13 +14,15 @@ export type MultiselectProps = {
   dataCy?: string;
   caption?: string;
   options: MultiselectOption[];
+  defaultValue?: MultiselectOption[];
   updateExternalState?: MultiselectExternalUpdate;
 };
 
-const Multiselect: React.FC<MultiselectProps> = ({
+const Multiselect: FC<MultiselectProps> = ({
   dataCy = "multiselect",
   caption,
   options,
+  defaultValue = [],
   updateExternalState
 }) => {
   const ref = useRef(null);
@@ -40,9 +42,11 @@ const Multiselect: React.FC<MultiselectProps> = ({
     item: "All",
     value: "all"
   });
+  const initialSelectedOptions =
+    defaultValue.length > 0 ? defaultValue : allOptions.slice(0, 1);
 
   const { getDropdownProps, setSelectedItems, selectedItems } =
-    useMultipleSelection({ initialSelectedItems: [allOptions[0]] });
+    useMultipleSelection({ initialSelectedItems: initialSelectedOptions });
 
   const addNewSelectedItem = (
     allCurrentlySelected: MultiselectOption[],
@@ -88,6 +92,10 @@ const Multiselect: React.FC<MultiselectProps> = ({
   useClickAway(ref, () => {
     setIsDropdownOpen(false);
   });
+
+  useDeepCompareEffect(() => {
+    setSelectedItems(initialSelectedOptions);
+  }, [setSelectedItems, initialSelectedOptions]);
 
   const { getToggleButtonProps, getMenuProps, highlightedIndex, getItemProps } =
     useSelect({


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/jira/software/c/projects/DDFSOEG/boards/468?selectedIssue=DDFSOEG-566

#### Description

Store the current query - either CQL or advanced search - in url  parameters when the user hits search. Conversely: When the advanced  search app is loaded transfer CQL or advanced search query from the url  to the state of the application.

To avoid mixing the two we introduce a separate state for the actual CQL query that is to be executed.

Another option would have been to only store CQL in the query but that approach introduces other problems: All advanced search queries can be transformed to CQL but not the other way around. Also creating a parser which can try to transform in both directions is pretty tricky.

To support setting material type, fiction and access filters support for defining default/preselected values is also added. Filters from the stored query is passed to the filter elements.

The Multiselect component has potential as a reusable component but is also getting quite complex so to support this works as expect Storybook support and Cypress testing is also added.

##### How to test

- Access the Advanced search story in Storybook
- Open the canvas in a new tab
- Fill out the form using all types of controls
- Click search
- See that the result is showing and that the url is updated
- Reload the page
- See that the filters and the result is the same
- Open the canvas from the story again
- Click "Edit CQL"
- Enter a query
- See that the search resul is showing that the url is updated
- Reload the page
- See that the query is the same and that the result is the same

<img width="2672" alt="Monosnap apps-advanced-search--advanced-search 2023-10-05 08-35-26" src="https://github.com/reload/dpl-react/assets/73966/876ac224-683d-4938-ba10-63a30bf80984">

<img width="2672" alt="Monosnap apps-advanced-search--advanced-search 2023-10-05 08-36-32" src="https://github.com/reload/dpl-react/assets/73966/e700c483-34b3-4ac4-ada2-87f49f369862">


