### PR TITLE
Set default start pause date as today

### DIFF
--- a/src/apps/reservation-list/modal/pause-reservation/pause-reservation.tsx
+++ b/src/apps/reservation-list/modal/pause-reservation/pause-reservation.tsx
@@ -1,4 +1,5 @@
 import React, { FC, useCallback, useState, useEffect, FormEvent } from "react";
+import dayjs from "dayjs";
 import { useQueryClient } from "react-query";
 import Link from "../../../../components/atoms/links/Link";
 import Modal, { useModalButtonHandler } from "../../../../core/utils/modal";
@@ -9,7 +10,6 @@ import {
 } from "../../../../core/fbs/fbs";
 import { Patron, PatronV5 } from "../../../../core/fbs/model";
 import { getModalIds } from "../../../../core/utils/helpers/general";
-import { useConfig } from "../../../../core/utils/config";
 import DateInputs from "../../../../components/date-inputs/date-inputs";
 import { useUrls } from "../../../../core/utils/url";
 
@@ -25,10 +25,8 @@ const PauseReservation: FC<PauseReservationProps> = ({ id, user }) => {
   const { mutate } = useUpdateV5();
   const { close } = useModalButtonHandler();
   const { pauseReservation } = getModalIds();
-  const config = useConfig();
-  const [startDate, setStartDate] = useState<string>(
-    config("pauseReservationStartDateConfig")
-  );
+  const currentDate = dayjs().format("YYYY-MM-DD");
+  const [startDate, setStartDate] = useState<string>(currentDate);
   const [endDate, setEndDate] = useState<string>("");
 
   const save = useCallback(


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-210

#### Description
We no longer want to control the pause start date from CMS, but always fallback to the current date